### PR TITLE
Bugfix | Skip poetry interactions when publishing to PyPI

### DIFF
--- a/.github/workflows/versioning-publisher.yml
+++ b/.github/workflows/versioning-publisher.yml
@@ -112,4 +112,4 @@ jobs:
       - name: Publish to PyPI
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-        run: poetry publish --build
+        run: poetry publish --skip-existing --no-interaction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "detquantlib"
-version = "2.0.3"
+version = "2.0.4"
 description = "An internal library containing functions and classes that can be used across Quant models."
 authors = ["DET"]
 readme = "README.md"


### PR DESCRIPTION
## Description

Skip Poetry confirmations when building the distribution. Avoids workflow getting stuck as below:

![image](https://github.com/user-attachments/assets/17dfb87d-f641-406c-93c7-e6ea13971a5e)

### Type of change

Please choose the options that are relevant.

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Chore (code refactoring, code style, updating tests, etc.)