### PR TITLE
Feature | Save Plotly figure to HTML file

### DIFF
--- a/detquantlib/figures/plotly_figures.py
+++ b/detquantlib/figures/plotly_figures.py
@@ -62,6 +62,35 @@ def save_plotly_fig_to_json(
         f.write(fig_json)
 
 
+def save_plotly_fig_to_html(
+    fig: go.Figure,
+    filename: str,
+    folder_dir: Path = get_default_plotly_folder_dir(),
+    standard_layout: bool = True,
+):
+    """
+    Saves a plotly figure object to an html file.
+
+    Args:
+        fig: Plotly figure
+        filename: Name of html file in which plotly figure will be saved
+        folder_dir: Folder directory where the html file will be saved
+        standard_layout: If true, enforces a standard plotly layout
+    """
+    # Create plotly folder if it doesn't exist yet
+    folder_dir.mkdir(parents=True, exist_ok=True)
+
+    # Define html file directory
+    file_dir = folder_dir.joinpath(f"{filename}.html")
+
+    # Adjust figure layout
+    if standard_layout:
+        fig = set_standard_layout(fig)
+
+    # Save figure to html
+    fig.write_html(file_dir)
+
+
 def show_plotly_fig_json(filename: str, folder_dir: Path = get_default_plotly_folder_dir()):
     """
     Short helper function to display a plotly figure stored in a json file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "detquantlib"
-version = "2.0.6"
+version = "2.1.6"
 description = "An internal library containing functions and classes that can be used across Quant models."
 authors = ["DET"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "detquantlib"
-version = "2.1.6"
+version = "2.1.0"
 description = "An internal library containing functions and classes that can be used across Quant models."
 authors = ["DET"]
 readme = "README.md"


### PR DESCRIPTION
## Description

Adds the possibility to save Plotly figures to HTML files.

### Type of change

Please choose the options that are relevant.

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Chore (code refactoring, code style, updating tests, etc.)