### PR TITLE
Feature | Support negative maturities when converting start date to maturity

### DIFF
--- a/detquantlib/dates/dates.py
+++ b/detquantlib/dates/dates.py
@@ -78,8 +78,8 @@ def calc_months_diff(
                 date and end date, irrespective of the day. For example, suppose that start date
                 is 15-Jan-2025 and end date is 3-Mar-2025. Then, the month difference between
                 Jan-2025 and Mar-2025 is 2.
-            - diff_method="time": Counts the month difference, accounting the day and time of the
-                start and end dates. For example:
+            - diff_method="time": Counts the month difference, accounting for the day and time
+                of the start and end dates. For example:
                 - Suppose that start date is 15-Jan-2025 and end date is 3-Mar-2025. Then:
                     - start date + 1 months = 15-Feb-2025
                     - start date + 2 months = 15-Mar-2025
@@ -103,7 +103,7 @@ def calc_months_diff(
         ValueError: Raises an error when the input argument 'diff_method' is invalid
     """
     # Input validation
-    if end_date < start_date:
+    if end_date < start_date and diff_method != "month":
         raise ValueError("End date cannot be smaller than start date.")
 
     # Calculate month difference

--- a/detquantlib/tradable_products/tradable_products.py
+++ b/detquantlib/tradable_products/tradable_products.py
@@ -34,13 +34,6 @@ def convert_delivery_start_date_to_maturity(
     # Make input product string lower case only
     product = product.lower()
 
-    # Validate input dates
-    if delivery_start_date < trading_date:
-        raise ValueError(
-            "Input argument 'delivery_start_date' cannot be smaller than input argument "
-            "'trading_date'."
-        )
-
     if product == "month":
         maturity = calc_months_diff(
             start_date=trading_date,
@@ -49,13 +42,13 @@ def convert_delivery_start_date_to_maturity(
         )
 
     elif product == "quarter":
-        quarter = pd.Timestamp(trading_date).quarter
-        year_start_date = datetime(trading_date.year, 1, 1)
-        trading_quarter_start_date = year_start_date + relativedelta(months=((quarter - 1) * 3))
+        trading_quarter_start_date = convert_maturity_to_delivery_start_date(
+            trading_date=trading_date, maturity=0, product="quarter"
+        )
 
-        quarter = pd.Timestamp(delivery_start_date).quarter
-        year_start_date = datetime(delivery_start_date.year, 1, 1)
-        delivery_quarter_start_date = year_start_date + relativedelta(months=((quarter - 1) * 3))
+        delivery_quarter_start_date = convert_maturity_to_delivery_start_date(
+            trading_date=delivery_start_date, maturity=0, product="quarter"
+        )
 
         months_diff = calc_months_diff(
             start_date=trading_quarter_start_date,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "detquantlib"
-version = "3.0.1"
+version = "3.0.2"
 description = "An internal library containing functions and classes that can be used across Quant models."
 authors = ["DET"]
 readme = "README.md"


### PR DESCRIPTION
## Description

Extends function `convert_delivery_start_date_to_maturity` so support `delivery_start_date` < `trading_date`.

This is needed to support common cases of maturity 0, where start date is set to the first day of the month (e.g. start date = 2025-04-01 and trading date = 2025-04-24).

### Type of change

Please choose the options that are relevant.

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Chore (code refactoring, code style, updating tests, etc.)