### PR TITLE
Chore | Expose functions

### DIFF
--- a/detquantlib/dates/__init__.py
+++ b/detquantlib/dates/__init__.py
@@ -1,1 +1,1 @@
-# Empty file required by poetry. Do not delete.
+from .dates import *

--- a/detquantlib/tradable_products/__init__.py
+++ b/detquantlib/tradable_products/__init__.py
@@ -1,1 +1,1 @@
-# Empty file required by poetry. Do not delete.
+from .tradable_products import *

--- a/detquantlib/utils/__init__.py
+++ b/detquantlib/utils/__init__.py
@@ -1,1 +1,1 @@
-# Empty file required by poetry. Do not delete.
+from .utils import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "detquantlib"
-version = "3.1.1"
+version = "3.1.2"
 description = "An internal library containing functions and classes that can be used across Quant models."
 authors = ["DET"]
 readme = "README.md"


### PR DESCRIPTION
## Description

Exposes the functions of the `dates`, `tradable_products` and `utils` modules to simplify imports. For instance, the user can now do `from detquantlib.utils import add_log` instead of `from detquantlib.utils.utils import add_log`.

### Type of change

Please choose the options that are relevant.

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Chore (code refactoring, code style, updating tests, etc.)