### PR TITLE
Bugfix | Fix default output folder when saving plotly figures

### DIFF
--- a/detquantlib/figures/plotly_figures.py
+++ b/detquantlib/figures/plotly_figures.py
@@ -30,10 +30,7 @@ def set_standard_layout(fig: go.Figure) -> go.Figure:
 
 
 def save_plotly_fig_to_json(
-    fig: go.Figure,
-    filename: str,
-    folder_dir: Path = PathDefinitions.get_outputs_plotly_folder_dir(),
-    standard_layout: bool = True,
+    fig: go.Figure, filename: str, folder_dir: Path = None, standard_layout: bool = True,
 ):
     """
     Saves a plotly figure object to a json file.
@@ -44,6 +41,9 @@ def save_plotly_fig_to_json(
         folder_dir: Folder directory where the json file will be saved
         standard_layout: If true, enforces a standard plotly layout
     """
+    if folder_dir is None:
+        PathDefinitions.get_outputs_plotly_folder_dir()
+
     # Create plotly folder if it doesn't exist yet
     folder_dir.mkdir(parents=True, exist_ok=True)
 
@@ -61,10 +61,7 @@ def save_plotly_fig_to_json(
 
 
 def save_plotly_fig_to_html(
-    fig: go.Figure,
-    filename: str,
-    folder_dir: Path = PathDefinitions.get_outputs_plotly_folder_dir(),
-    standard_layout: bool = True,
+    fig: go.Figure, filename: str, folder_dir: Path = None, standard_layout: bool = True
 ):
     """
     Saves a plotly figure object to an html file.
@@ -75,6 +72,9 @@ def save_plotly_fig_to_html(
         folder_dir: Folder directory where the html file will be saved
         standard_layout: If true, enforces a standard plotly layout
     """
+    if folder_dir is None:
+        folder_dir = PathDefinitions.get_outputs_plotly_folder_dir()
+
     # Create plotly folder if it doesn't exist yet
     folder_dir.mkdir(parents=True, exist_ok=True)
 
@@ -89,9 +89,7 @@ def save_plotly_fig_to_html(
     fig.write_html(file_dir)
 
 
-def show_plotly_fig_json(
-    filename: str, folder_dir: Path = PathDefinitions.get_outputs_plotly_folder_dir()
-):
+def show_plotly_fig_json(filename: str, folder_dir: Path = None):
     """
     Short helper function to display a plotly figure stored in a json file.
 
@@ -99,6 +97,9 @@ def show_plotly_fig_json(
         filename: Name of json file containing the plotly figure
         folder_dir: Folder directory containing the json file
     """
+    if folder_dir is None:
+        PathDefinitions.get_outputs_plotly_folder_dir()
+
     # Get json file directory
     file_dir = folder_dir.joinpath(f"{filename}.json")
 

--- a/detquantlib/figures/plotly_figures.py
+++ b/detquantlib/figures/plotly_figures.py
@@ -30,7 +30,7 @@ def set_standard_layout(fig: go.Figure) -> go.Figure:
 
 
 def save_plotly_fig_to_json(
-    fig: go.Figure, filename: str, folder_dir: Path = None, standard_layout: bool = True,
+    fig: go.Figure, filename: str, folder_dir: Path = None, standard_layout: bool = True
 ):
     """
     Saves a plotly figure object to a json file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "detquantlib"
-version = "3.8.0"
+version = "3.8.1"
 description = "An internal library containing functions and classes that can be used across Quant models."
 authors = ["DET"]
 readme = "README.md"


### PR DESCRIPTION
## Description

Related to https://github.com/Dynamic-Energy-Trading/detquantlib/pull/63

In the functions `save_plotly_fig_to_json()`, `save_plotly_fig_to_html()` and `show_plotly_fig_json()`, the default value of the input argument `folder_dir` is specified directly with the input argument. For example, in line 66 below:

https://github.com/Dynamic-Energy-Trading/detquantlib/blob/81babbfea51e0c08544365c57c4a81285f5be3e7/detquantlib/figures/plotly_figures.py#L63-L68

Since the code change implemented in https://github.com/Dynamic-Energy-Trading/detquantlib/pull/63, the method `PathDefinitions.get_outputs_plotly_folder_dir()` then fetches the output folder name from a dedicated environment variable.

**Problem:**

- Python does not set the default value when the function is **called**, but when the function is **imported**.
- In most Quant models:
  - The output folder name is a user input, and it is stored in a dedicated environment variable when loading all the inputs.
  - The function is imported before any code is run.
- As a result, Python sets the default value before the environment variable has been created.

**Solution:**

Instead of defining the default value of `folder_dir` in the arguments definition, it should be set inside the function.

### Type of change

Please choose the options that are relevant.

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Chore (code refactoring, code style, updating tests, etc.)